### PR TITLE
ci(smoke): scaffold + bring up --next project on every PR

### DIFF
--- a/.github/workflows/init-smoke.yml
+++ b/.github/workflows/init-smoke.yml
@@ -1,0 +1,213 @@
+name: Init smoke (--next)
+
+# End-to-end bring-up test for `lt fullstack init --next`. Runs on every PR
+# and every push to main so that mechanical regressions in the scaffolding
+# flow (P1000 auth from leftover Postgres state, missing `pg_uuidv7`,
+# empty `datasource.url`, hard-coded `container_name:` clashes, missing
+# `prepare:schema` step before `prisma:generate`, etc.) are caught before
+# they reach humans.
+#
+# The workflow exercises the CLI from THIS PR — never the published npm
+# version — by doing `npm pack` and a global install of the resulting
+# tarball. After scaffolding it boots Postgres, materialises the feature-
+# gated migrations, runs Prisma migrate, and compiles the generated API.
+# Boot/health-check is intentionally OUT of scope for now; the migrate-
+# and-build step already catches the bulk of the bring-up bugs that have
+# shown up in the friction log, and adding a live server would just make
+# the workflow flakier.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# Cancel superseded runs on the same branch — saves CI minutes when a
+# contributor pushes follow-up commits while the previous run is still
+# building the Postgres image.
+concurrency:
+  group: init-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: lt fullstack init --next
+    runs-on: ubuntu-latest
+    # The Postgres image build (compiles pg_uuidv7 from source) is the
+    # dominant cost: ~2-3 min on a cold runner. 25 min gives generous
+    # headroom for npm install + clone + migrate + compile on top.
+    timeout-minutes: 25
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Build the CLI from the PR's source so the smoke test exercises
+      # the actual code under review, not whatever is on npm. `npm run
+      # build` already runs lint + tests + compile + copy-templates.
+      - name: Install CLI dependencies
+        run: npm install
+
+      - name: Build CLI
+        run: npm run build
+
+      # `npm pack` produces the same tarball that `npm publish` would
+      # ship, so installing it globally exercises the published surface
+      # (bin/lt, build/, files[]) — not the dev-mode ts-node path.
+      - name: Pack CLI
+        id: pack
+        run: |
+          set -euo pipefail
+          tarball="$(npm pack --silent)"
+          echo "tarball=${tarball}" >> "$GITHUB_OUTPUT"
+          echo "Packed: ${tarball}"
+
+      - name: Install CLI globally
+        run: npm install -g "./${{ steps.pack.outputs.tarball }}"
+
+      - name: Verify lt is on PATH
+        run: |
+          which lt
+          lt --version || true
+
+      # Scaffold into $RUNNER_TEMP so the cli checkout stays clean. The
+      # generated workspace clones lt-monorepo + nest-base over HTTPS;
+      # GitHub-hosted runners have outbound internet by default.
+      - name: Scaffold --next workspace
+        working-directory: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          lt fullstack init \
+            --name smoke \
+            --frontend nuxt \
+            --next \
+            --noConfirm
+
+      # The generated API lives under projects/api/. Everything from here
+      # mirrors the documented bring-up sequence in the workspace's
+      # .claude/QUICKSTART.md (added in PR #81).
+      - name: Install API dependencies (bun)
+        working-directory: ${{ runner.temp }}/smoke/projects/api
+        run: bun install
+
+      # `bun run setup` substitutes random secrets into .env.example. It
+      # is idempotent (refuses to overwrite an existing .env), which is
+      # fine — the workspace is freshly scaffolded so no .env exists yet.
+      - name: Generate .env (bun run setup)
+        working-directory: ${{ runner.temp }}/smoke/projects/api
+        run: bun run setup
+
+      # Build only the postgres service. The custom image compiles
+      # pg_uuidv7 from source, so first build takes a few minutes.
+      # Pre-building / caching this image is deliberately out of scope
+      # for this PR — that's an optimisation we can layer in later.
+      - name: Start Postgres (docker compose)
+        working-directory: ${{ runner.temp }}/smoke/projects/api
+        run: docker compose up -d --build postgres
+
+      # Poll the compose-defined healthcheck instead of `pg_isready`
+      # against a fixed port — the compose project name is auto-derived
+      # from the workspace dir (since nest-base 25963e0 dropped the
+      # hard-coded `name:`/`container_name:`), so locating the container
+      # by service name is the stable approach. `docker inspect` on the
+      # service container avoids parsing JSON-line output of `compose ps`.
+      - name: Wait for Postgres healthcheck
+        working-directory: ${{ runner.temp }}/smoke/projects/api
+        run: |
+          set -euo pipefail
+          cid="$(docker compose ps -q postgres)"
+          if [ -z "${cid}" ]; then
+            echo "No postgres container — compose up did not produce one."
+            docker compose ps
+            exit 1
+          fi
+          for i in $(seq 1 60); do
+            status="$(docker inspect -f '{{.State.Health.Status}}' "${cid}" 2>/dev/null || echo "starting")"
+            echo "attempt ${i}: ${status}"
+            if [ "${status}" = "healthy" ]; then
+              echo "Postgres is healthy."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Postgres did not become healthy in time."
+          docker compose logs postgres
+          exit 1
+
+      # PR #81 (nest-base side) introduced `prepare:schema`, which
+      # concatenates the feature-gated schemas under prisma/features/
+      # into the final schema and materialises matching migrations.
+      # MUST run before `prisma:generate` and `prisma:migrate` — without
+      # it Prisma sees an empty datasource and exits with the kind of
+      # opaque error the friction log was full of.
+      - name: Prepare Prisma schema
+        working-directory: ${{ runner.temp }}/smoke/projects/api
+        run: bun run prepare:schema
+
+      - name: Generate Prisma client
+        working-directory: ${{ runner.temp }}/smoke/projects/api
+        run: bun run prisma:generate
+
+      - name: Run Prisma migrations
+        working-directory: ${{ runner.temp }}/smoke/projects/api
+        run: bun run prisma:migrate
+
+      - name: Build API
+        working-directory: ${{ runner.temp }}/smoke/projects/api
+        run: bun run build
+
+      # On failure, dump the most useful diagnostics inline BEFORE the
+      # teardown removes the containers. The full workspace is uploaded
+      # as an artifact below so the bring-up can be reproduced after
+      # the runner is recycled. We `cd` inside the script so the step
+      # still runs (and prints something useful) even when scaffolding
+      # itself failed and the API dir doesn't exist yet.
+      - name: Dump compose logs on failure
+        if: failure()
+        run: |
+          api_dir="${{ runner.temp }}/smoke/projects/api"
+          if [ ! -d "${api_dir}" ]; then
+            echo "API directory not present — scaffolding likely failed before docker came up."
+            exit 0
+          fi
+          cd "${api_dir}"
+          echo "--- docker compose ps ---"
+          docker compose ps || true
+          echo "--- docker compose logs (postgres, last 200 lines) ---"
+          docker compose logs --tail=200 postgres || true
+
+      - name: Upload generated workspace on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-workspace-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/smoke
+            !${{ runner.temp }}/smoke/**/node_modules
+            !${{ runner.temp }}/smoke/**/.git
+          retention-days: 7
+          if-no-files-found: ignore
+
+      # Hygiene — runners are ephemeral but leaking state inside a single
+      # job makes re-running the same step locally with `act` painful.
+      # `down -v` drops the named volume, so a re-run starts from a
+      # clean slate (no P1000 auth errors from a stale data dir). Runs
+      # AFTER the failure-dump step so the logs are still available.
+      - name: Tear down docker compose
+        if: always()
+        run: |
+          api_dir="${{ runner.temp }}/smoke/projects/api"
+          if [ -d "${api_dir}" ]; then
+            cd "${api_dir}"
+            docker compose down -v || true
+          fi


### PR DESCRIPTION
## Summary

The friction log on `lt fullstack init --next` keeps surfacing the same class of mechanical bug — P1000 auth errors from leftover Postgres state, missing `pg_uuidv7` extension, empty `datasource.url`, hard-coded `container_name:` clashes across workspaces, `prepare:schema` not run before `prisma:generate`. None of these are caught by the existing jest unit tests because they only reproduce when the generated workspace actually boots against Postgres. So they reach humans first.

This PR adds a GitHub Actions workflow (`.github/workflows/init-smoke.yml`) that runs on every PR and every push to `main`. It builds the CLI from the PR's source (so the test exercises the actual code under review, not whatever is on npm), `npm pack`s + globally installs the tarball, then scaffolds a real `--next` workspace into `$RUNNER_TEMP` and walks it through the documented bring-up.

## What the workflow does

1. **Build CLI from source** — `npm install`, `npm run build` (which already runs lint + tests + compile + copy-templates).
2. **Pack + global install** — `npm pack` + `npm install -g ./<tarball>`. This exercises the same install surface real users get (`bin/lt`, `build/`, `files[]`), not the dev-mode ts-node path.
3. **Scaffold** in `$RUNNER_TEMP`:
   ```
   lt fullstack init --name smoke --frontend nuxt --next --noConfirm
   ```
4. **Bring up the API** in the order from the workspace's `.claude/QUICKSTART.md` (added in #81):
   ```
   bun install
   bun run setup            # writes .env from .env.example
   docker compose up -d --build postgres
   <wait for healthcheck>
   bun run prepare:schema   # materialise feature-gated migrations
   bun run prisma:generate
   bun run prisma:migrate
   bun run build
   ```
5. **Tear down** with `docker compose down -v` regardless of outcome.

## Notes / tradeoffs

- **No boot/health-check yet.** The task brief flagged it as optional, and the migrate-and-build step already catches the bulk of bring-up regressions. We can layer in a `bun run dev &` + `/health/ready` + `/api/openapi.json` smoke later once this workflow has shaken out.
- **Postgres image build (~2-3 min).** The custom image compiles `pg_uuidv7` from source on first build. Pre-build / cache is deliberately deferred — that's an optimisation for after we have signal on stability.
- **Concurrency group** — cancels superseded runs on the same ref so a fast follow-up commit doesn't queue a full rebuild.
- **Failure diagnostics** — dumps `docker compose ps` + last 200 lines of `postgres` logs inline, then uploads the full generated workspace (minus `node_modules` / `.git`) as an artifact for 7 days so the bring-up can be reproduced after the runner is recycled.
- **Compose project naming** — relies on `nest-base` having dropped the hard-coded `name:` / `container_name:` (commit `25963e0`), so the compose project is auto-derived from the workspace dir and parallel runs don't clash.
- **Scope** — only `.github/workflows/init-smoke.yml`. No CLI source changes.

## Test plan

- [x] `npm run lint` — clean (pre-push hook)
- [x] `npm test` — 153 passed (pre-push hook)
- [x] YAML parses (`yq eval '.' .github/workflows/init-smoke.yml`)
- [ ] First CI run on this PR — observe the workflow end-to-end, confirm it goes green against current `main` of `lenneTech/nest-base`. Any flake or unexpected failure should be triaged before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)