### PR TITLE
fix(server create): tolerate non-git cwd when checking work tree

### DIFF
--- a/src/commands/server/create.ts
+++ b/src/commands/server/create.ts
@@ -287,9 +287,12 @@ const NewCommand: GluegunCommand = {
       return `created server symlink ${name}`;
     }
 
-    // Git initialization (after npm install which is done in setupServer)
+    // Git initialization (after npm install which is done in setupServer).
+    // When cwd is not inside a repo, `git rev-parse` exits 128 — treat as false.
     if (git) {
-      const inGit = (await system.run('git rev-parse --is-inside-work-tree'))?.trim();
+      const inGit = (
+        await system.run('git rev-parse --is-inside-work-tree 2>/dev/null || echo false')
+      )?.trim();
       if (inGit !== 'true') {
         // Determine initGit with priority: CLI > config > interactive
         let initializeGit: boolean;


### PR DESCRIPTION
## Summary

- Fixes `lt server create` (including `--next`) aborting after a successful template clone when run outside a git repository
- `git rev-parse --is-inside-work-tree` now treats exit code 128 as "not in a work tree" instead of failing the command

## Test plan

- [x] `npm test` (pre-push hook)
- [ ] Run `lt server create bp-api --next --noConfirm` from a directory that is not a git repo and confirm it completes with next steps printed
- [ ] Run the same command from inside an existing git repo and confirm behavior is unchanged (no nested `git init` unless `--git` is set)