### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,15 @@ on:
   release:
     types:
       - released
+  workflow_dispatch:
+
+# Trusted Publishing (OIDC): npm mints a short-lived, workflow-scoped token
+# at run time — no long-lived NPM_TOKEN secret to expire or rotate.
+# Requires a Trusted Publisher configured on npmjs.com for this repo +
+# workflow filename, npm >= 11.5.1, and Node >= 22.14.0.
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   publish:
@@ -11,15 +20,16 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
-      - name: Node 20
+      - name: Node 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
       - name: NPM install
         run: npm install
       - name: Build
         run: npm run build
       - name: Publish
-        uses: JS-DevTools/npm-publish@v3
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+        run: npm publish


### PR DESCRIPTION
## Why

npm granular access tokens have a max expiry and classic non-expiring automation tokens are being deprecated. The `NPM_TOKEN` secret expired and silently broke the 1.24.1 publish (404 on PUT). Rotating a token just resets the timer.

## What

Switch the Publish workflow to **npm Trusted Publishing (OIDC)** — npm mints a short-lived, workflow-scoped token at run time. No `NPM_TOKEN` secret, nothing to expire or rotate.

- `permissions: id-token: write`
- Node 20 → 22 (OIDC needs Node ≥ 22.14.0) + `npm install -g npm@latest` (OIDC support landed in npm 11.5.1)
- Drop `JS-DevTools/npm-publish@v3` + `secrets.NPM_TOKEN` → plain `npm publish`
- Add `workflow_dispatch` so an existing release can be (re-)published without recreating the GitHub Release

## Prerequisite (done)

A Trusted Publisher is configured on npmjs.com for `@lenne.tech/cli` → repo `lenneTech/cli`, workflow `publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)